### PR TITLE
Only swallow SIG once

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = {
 			server.log('graceful-stop', 'Server stopped');
 		}
 
-		process.on('SIGINT', async () => await shutdown('SIGINT'));
-		process.on('SIGTERM', async () => await shutdown('SIGTERM'));
+		process.once('SIGINT', async () => await shutdown('SIGINT'));
+		process.once('SIGTERM', async () => await shutdown('SIGTERM'));
 	}
 };


### PR DESCRIPTION
If the event loop is blocked, this lib currently does not allow the application to be terminated properly using ordinary kill signals. Only something along the lines of `kill -9 <pid>` will do. This is because the lib will eternally yank all SIGTERM/SIGINT it receives.

Correct this to only do graceful shutdown on the first such signal received, then allow any subsequent signals to terminate the process as usual.

You can test this by putting something in your postStop like `while (true) {}`.