### PR TITLE
Always register listener for stop-event

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,12 @@ module.exports = {
 			gracefulTerminationTimeout: timeout * 0.9
 		});
 
+		server.events.on('stop', () => {
+			exit(afterStopTimeout, options.afterStop, server);
+		});
+
 		async function shutdown(signal) {
 			server.log('graceful-stop', `Received ${signal}, initiating graceful stop with timeout ${timeout} ms`);
-
-			server.events.on('stop', () => {
-				exit(afterStopTimeout, options.afterStop, server);
-			});
-
 			await terminator.terminate();
 			await server.stop({timeout: afterStopTimeout});
 			server.log('graceful-stop', 'Server stopped');


### PR DESCRIPTION
Currently, the `on('stop')`-listener is only registered when the app receives SIGINT or SIGTERM. This means post-shutdown hooks don't run if you call `server.stop()` on the Hapi server manually. This has become an issue for me in tests that operate on a Hapi instance, as I can't close it cleanly afterwards.

Registering these in the scope above shouldn't pose any issues.