### PR TITLE
Revert "Always register listener for stop-event"

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,12 +32,13 @@ module.exports = {
 			gracefulTerminationTimeout: timeout * 0.9
 		});
 
-		server.events.on('stop', () => {
-			exit(afterStopTimeout, options.afterStop, server);
-		});
-
 		async function shutdown(signal) {
 			server.log('graceful-stop', `Received ${signal}, initiating graceful stop with timeout ${timeout} ms`);
+
+			server.events.on('stop', () => {
+				exit(afterStopTimeout, options.afterStop, server);
+			});
+
 			await terminator.terminate();
 			await server.stop({timeout: afterStopTimeout});
 			server.log('graceful-stop', 'Server stopped');


### PR DESCRIPTION
Reverts aptoma/hapi-graceful-stop#7.

:)

The afterStop-callback always calls process.exit, so if it runs during tests, it'll kill the entire rest of the test suite with a 0 error code. I'll unpublish 3.3.1 and take this back to the drawing board. Sorry about the back-and-forth.