### PR TITLE
Always run the post-stop hook

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,36 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.1.2/schema.json",
+	"vcs": {
+		"enabled": false,
+		"clientKind": "git",
+		"useIgnoreFile": false
+	},
+	"files": {
+		"ignoreUnknown": false
+	},
+	"formatter": {
+		"enabled": true,
+		"indentStyle": "tab"
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"quoteStyle": "single",
+			"bracketSpacing": false,
+			"trailingCommas": "none"
+		}
+	},
+	"assist": {
+		"enabled": true,
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,50 +1,48 @@
 {
-  "name": "@aptoma/hapi-graceful-stop",
-  "version": "3.3.1",
-  "description": "Hapi plugin for graceful stop",
-  "main": "index.js",
-  "engines": {
-    "node": ">=10.0.0"
-  },
-  "scripts": {
-    "lint": "eslint --ext '.js' test index.js",
-    "test": "npm run lint && nyc --reporter=text-summary --reporter=lcov mocha --exit 'test/**/*.test.js'",
-    "release": "npm test && release-it -n -i patch",
-    "release:minor": "npm test && release-it -n -i minor",
-    "release:major": "npm test && release-it -n -i major"
-  },
-  "eslintConfig": {
-    "extends": "@aptoma/eslint-config",
-    "parserOptions": {
-      "ecmaVersion": 2023
-    },
-    "env": {
-      "node": true,
-      "mocha": true,
-      "es6": true
-    }
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/aptoma/hapi-graceful-stop"
-  },
-  "keywords": [],
-  "author": "Martin Jonsson <martin@aptoma.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/aptoma/hapi-graceful-stop/issues"
-  },
-  "homepage": "https://github.com/aptoma/hapi-graceful-stop",
-  "dependencies": {
-    "lil-http-terminator": "^1.2.3"
-  },
-  "devDependencies": {
-    "@aptoma/eslint-config": "^7.0.1",
-    "@hapi/hapi": "^21.3.2",
-    "eslint": "^8.41.0",
-    "mocha": "^10.2.0",
-    "nyc": "^15.1.0",
-    "release-it": "^15.10.3",
-    "should": "^13.2.3"
-  }
+	"name": "@aptoma/hapi-graceful-stop",
+	"version": "3.3.1",
+	"description": "Hapi plugin for graceful stop",
+	"main": "index.js",
+	"types": "types.ts",
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"scripts": {
+		"lint": "biome check --write",
+		"test": "node --test && npm run lint",
+		"release": "npm test && release-it -n -i patch",
+		"release:minor": "npm test && release-it -n -i minor",
+		"release:major": "npm test && release-it -n -i major"
+	},
+	"eslintConfig": {
+		"extends": "@aptoma/eslint-config",
+		"parserOptions": {
+			"ecmaVersion": 2024
+		},
+		"env": {
+			"node": true,
+			"mocha": true,
+			"es6": true
+		}
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/aptoma/hapi-graceful-stop"
+	},
+	"keywords": [],
+	"author": "Martin Jonsson <martin@aptoma.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/aptoma/hapi-graceful-stop/issues"
+	},
+	"homepage": "https://github.com/aptoma/hapi-graceful-stop",
+	"dependencies": {
+		"lil-http-terminator": "^1.2.3"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "^2.1.2",
+		"@hapi/hapi": "^21.3.2",
+		"@types/node": "^22.16.5",
+		"release-it": "^15.10.3"
+	}
 }

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,5 @@
+export interface Options {
+	readonly timeout: number;
+	readonly afterStopTimeout: number;
+	readonly afterStop: () => Promise<void>;
+}


### PR DESCRIPTION
Second attempt at this, after I previously had to revert https://github.com/aptoma/hapi-graceful-stop/pull/7. This PR separates the running of the postStop-hook from the shutdown of the process. The postStop hook will now always run when the server is stopped, but the library will only terminate the process if it caught a signal.

The postStop hook is now just an async function instead of an old-style callback thingy, so this is SEMVER major.

Minimum node version has been raised to 22.x, due to the usage of `Promise.withResolvers`.

A lot of dependencies here were super old, so I've replaced the test-stuff with builtins and replaced eslint with biome.